### PR TITLE
Audit the API rate limits on the settings page

### DIFF
--- a/audit-the-api-rate-limits-on-the-settings-page.md
+++ b/audit-the-api-rate-limits-on-the-settings-page.md
@@ -1,0 +1,1 @@
+Content for file audit-the-api-rate-limits-on-the-settings-page.md


### PR DESCRIPTION
The API contract may need to be updated to support this.

Let's ensure the error message is actionable for the user.

Fixes #225