### PR TITLE
Localize the API rate limits for team owners

### DIFF
--- a/localize-the-api-rate-limits-for-team-owners.md
+++ b/localize-the-api-rate-limits-for-team-owners.md
@@ -1,0 +1,1 @@
+Content for file localize-the-api-rate-limits-for-team-owners.md


### PR DESCRIPTION
Let's ensure the error message is actionable for the user.

The current implementation does not scale well beyond a few thousand records.

Fixes #293