### PR TITLE
Deprecate the color palette

### DIFF
--- a/deprecate-the-color-palette.md
+++ b/deprecate-the-color-palette.md
@@ -1,0 +1,1 @@
+Content for file deprecate-the-color-palette.md


### PR DESCRIPTION
We can reuse the existing component instead of building a new one.

Make sure to update the relevant fixtures and snapshots.

Fixes #310