### PR TITLE
Streamline the loading indicators in the onboarding tour

### DIFF
--- a/streamline-the-loading-indicators-in-the-onboarding-tour.md
+++ b/streamline-the-loading-indicators-in-the-onboarding-tour.md
@@ -1,0 +1,1 @@
+Content for file streamline-the-loading-indicators-in-the-onboarding-tour.md


### PR DESCRIPTION
There is a temporary workaround in place that we should remove afterwards.

Fixes #339