### PR TITLE
Remove the API rate limits on mobile

### DIFF
--- a/remove-the-api-rate-limits-on-mobile.md
+++ b/remove-the-api-rate-limits-on-mobile.md
@@ -1,0 +1,1 @@
+Content for file remove-the-api-rate-limits-on-mobile.md


### PR DESCRIPTION
The change should be backward compatible and require no migration.

This blocks a couple of downstream tasks, so it should be prioritized.

Fixes #368