### PR TITLE
Decouple the date picker for free-tier users

### DIFF
--- a/decouple-the-date-picker-for-free-tier-users.md
+++ b/decouple-the-date-picker-for-free-tier-users.md
@@ -1,0 +1,1 @@
+Content for file decouple-the-date-picker-for-free-tier-users.md


### PR DESCRIPTION
This was flagged during the last round of QA testing.

Fixes #370