### PR TITLE
Cache the navigation menu in the onboarding tour

### DIFF
--- a/cache-the-navigation-menu-in-the-onboarding-tour.md
+++ b/cache-the-navigation-menu-in-the-onboarding-tour.md
@@ -1,0 +1,1 @@
+Content for file cache-the-navigation-menu-in-the-onboarding-tour.md


### PR DESCRIPTION
This depends on the new endpoint that the backend team is shipping.

Documentation will need to be updated once this is merged.

This was flagged during the last round of QA testing.

Fixes #353