### PR TITLE
Enhance the API rate limits for team owners

### DIFF
--- a/enhance-the-api-rate-limits-for-team-owners.md
+++ b/enhance-the-api-rate-limits-for-team-owners.md
@@ -1,0 +1,1 @@
+Content for file enhance-the-api-rate-limits-for-team-owners.md


### PR DESCRIPTION
There is a temporary workaround in place that we should remove afterwards.

Fixes #367