### PR TITLE
Decouple the settings page during peak traffic

### DIFF
--- a/decouple-the-settings-page-during-peak-traffic.md
+++ b/decouple-the-settings-page-during-peak-traffic.md
@@ -1,0 +1,1 @@
+Content for file decouple-the-settings-page-during-peak-traffic.md


### PR DESCRIPTION
The current implementation does not scale well beyond a few thousand records.

Fixes #447