### PR TITLE
Implement the API rate limits on the settings page

### DIFF
--- a/implement-the-api-rate-limits-on-the-settings-page.md
+++ b/implement-the-api-rate-limits-on-the-settings-page.md
@@ -1,0 +1,1 @@
+Content for file implement-the-api-rate-limits-on-the-settings-page.md


### PR DESCRIPTION
This depends on the new endpoint that the backend team is shipping.

Edge cases around empty states and errors must be handled gracefully.

Several users have reported confusion around this area.

Fixes #496