### PR TITLE
Harden the help center in the onboarding tour

### DIFF
--- a/harden-the-help-center-in-the-onboarding-tour.md
+++ b/harden-the-help-center-in-the-onboarding-tour.md
@@ -1,0 +1,1 @@
+Content for file harden-the-help-center-in-the-onboarding-tour.md


### PR DESCRIPTION
The change should be backward compatible and require no migration.

This came up while reviewing feedback from the product team.

There is a temporary workaround in place that we should remove afterwards.

Fixes #624