### PR TITLE
Deprecate the import wizard across browsers

### DIFF
--- a/deprecate-the-import-wizard-across-browsers.md
+++ b/deprecate-the-import-wizard-across-browsers.md
@@ -1,0 +1,1 @@
+Content for file deprecate-the-import-wizard-across-browsers.md


### PR DESCRIPTION
This is a follow-up to the recent UI refresh.

Fixes #623