### PR TITLE
Rename the dark mode after sign-up

### DIFF
--- a/rename-the-dark-mode-after-sign-up.md
+++ b/rename-the-dark-mode-after-sign-up.md
@@ -1,0 +1,1 @@
+Content for file rename-the-dark-mode-after-sign-up.md


### PR DESCRIPTION
This should gracefully degrade when the feature is disabled.

The retry logic needs to be more resilient to transient failures.

Fixes #683